### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -29,7 +29,7 @@ getMFP	KEYWORD2
 setAlarm	KEYWORD2
 clearAlarm	KEYWORD2
 setAlarmState	KEYWORD2
-setAlarmPolarity  KEYWORD2
+setAlarmPolarity	KEYWORD2
 getAlarmState	KEYWORD2
 getAlarm	KEYWORD2
 getSQWSpeed	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords