### PR TITLE
Added method calibrateOrAdjust and fixed potential overflow bug.

### DIFF
--- a/src/MCP7940.cpp
+++ b/src/MCP7940.cpp
@@ -596,9 +596,20 @@ int32_t MCP7940_Class::getPPMDeviation(const DateTime& dt){
   return ppm;
 }
 
+/*!
+    @brief   Set the time the clock was last calibrated or adjusted.
+    @details Set the internal variable _SetUnixTime.  This is the time the clock was last calibrated or adjusted.  This should only used to testing.  
+    @param[in] aTime is the Unix time to set the time the clock was last calibrated or adjusted to.
+    @return  void
+*/
 void MCP7940_Class::setSetUnixTime(uint32_t aTime){
 	_SetUnixTime = aTime;
 }
+/*!
+    @brief   Get the time the clock was last calibrated or adjusted.
+    @details Returns the internal variable _SetUnixTime.  This is the time the clock was last calibrated or adjusted.  This should only used to testing.  
+    @return  Returns the internal variable _SetUnixTime.
+*/
 uint32_t MCP7940_Class::getSetUnixTime(){
 	return _SetUnixTime;
 }

--- a/src/MCP7940.cpp
+++ b/src/MCP7940.cpp
@@ -569,14 +569,15 @@ int8_t MCP7940_Class::calibrate(const DateTime& dt)
 			 is 225 ppm.  If the ppm deviation is within -130 to 130 then assume we are just calibrating
 			 the clock.  
     @param[in] dt Actual Date/time
-    @return  Returns Void
+    @return  Returns the trim value
 */
-void MCP7940_Class::calibrateOrAdjust(const DateTime& dt){
+int8_t MCP7940_Class::calibrateOrAdjust(const DateTime& dt){
   int32_t ppm = getPPMDeviation(dt);
   if ((ppm > 130) || (ppm < -130)){  // calibration is out of range so just set the time  DML 2/5/2019
 	  adjust(dt);
+	  return readByte(MCP7940_OSCTRIM);
   }else{
-	  calibrate(dt);
+	  return calibrate(dt);
   }
 }
 /*!
@@ -587,12 +588,21 @@ void MCP7940_Class::calibrateOrAdjust(const DateTime& dt){
 			 the clock.  
     @param[in] dt Actual Date/time
     @return  Returns Void
-*/int32_t MCP7940_Class::getPPMDeviation(const DateTime& dt){
+*/
+int32_t MCP7940_Class::getPPMDeviation(const DateTime& dt){
   int32_t SecDeviation = dt.unixtime() - now().unixtime();     // Get difference in seconds
   int32_t ExpectedSec  = dt.unixtime() - _SetUnixTime;      // Get number of seconds since set
   int32_t          ppm = 1000000 * SecDeviation / ExpectedSec; // Multiply first to avoid truncation
   return ppm;
 }
+
+void MCP7940_Class::setSetUnixTime(uint32_t aTime){
+	_SetUnixTime = aTime;
+}
+uint32_t MCP7940_Class::getSetUnixTime(){
+	return _SetUnixTime;
+}
+
 /*!
     @brief   Calibrate the MCP7940 (overloaded)
     @details When called with one floating point value then that is used as the measured frequency

--- a/src/MCP7940.h
+++ b/src/MCP7940.h
@@ -1,71 +1,68 @@
-/***************************************************************************************************************//*!
-* @file MCP7940.h
-*
-*  @mainpage Arduino Library Header for the MCP7940M and MCP7940N Real-Time Clock devices
-*
-*  @section MCP7940_intro_section Description
-*
-* Class definition header for the MCP7940 from Microchip. Both the MCP7940N (with battery backup pin= and the
-* MCP7940M are supported with this library and they both use the same I2C address. This chip is a Real-Time-Clock
-* with an I2C interface. The data sheet located at http://ww1.microchip.com/downloads/en/DeviceDoc/20002292B.pdf
-* describes the functionality used in this library.\n
-* Use is made of portions of Adafruit's RTClib Version 1.2.0 at https://github.com/adafruit/RTClib which is a
-* a fork of the original RTClib from Jeelabs. The re-used code encompasses only the classes for time and date.\n
-*
-* @section license GNU General Public License v3.0
-* This program is free software: you can redistribute it and/or modify it under the terms of the GNU General
-* Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
-* option) any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY
-* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU General Public License for more details. You should have received a copy of the GNU General Public License
-* along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*
-* @section author Author
-*
-* Written by Arnd\@SV-Zanshin
-*
-* @section versions Changelog
-* 
-* Version| Date       | Developer           | Comments
-* ------ | ---------- | ------------------- | --------
-* 1.1.7  | 2019-02-07 | davidlehrian        | Issue #43 - Calibration might cause overflow of "trim" variable
-* 1.1.7  | 2019-02-07 | davidlehrian        | Issue #42 - calibrate(DateTime) should correct the current date/time
-* 1.1.6  | 2019-01-27 | davidlehrian        | Issue #36 - Reopened, changed assignment statements to avoid warning
-* 1.1.5  | 2019-01-19 | SV-Zanshin          | Issue #40 - Change commenting structure and layout to use doxygen
-* 1.1.5  | 2019-01-19 | INemesisI           | Issue #37 - Corrected AlarmPolarity bit clearing on setAlarm()
-* 1.1.5  | 2019-01-19 | SV-Zanshin          | Issue #39 - Small changes to remove compiler warnings for Travis-CI
-* 1.1.5  | 2019-01-18 | INemesisI           | Issue #38 - Overflow on setting new TRIM value
-* 1.1.4  | 2018-12-15 | hexeguitar          | Issue #36 - Overflow on I2C_MODES datatype corrected
-* 1.1.4  | 2018-12-15 | huynh213            | Issue #35 - MCP7940.adjust() function resets the PWRFAIL and VBATEN
-* 1.1.3  | 2018-08-08 | amgrays             | Issue #32 - invalid return on SetMFP corrected
-* 1.1.3  | 2018-08-05 | HannesJo0139        | Issue #31 - incorrect calibration trim on negative numbers
-* 1.1.2  | 2018-08-04 | SV-Zanshin          | Issue #28 - added new calibrate() overload for frequency calibration
-* 1.1.2  | 2018-07-08 | logicaprogrammabile | Issue #26 - regarding hour bitmasks
-* 1.1.1  | 2018-07-07 | SV-Zanshin          | Fixed bugs introduced by 14, 20, and 21
-* 1.1.1  | 2018-07-07 | wvmarle             | Pull #21  - Additional changes
-* 1.1.1  | 2018-07-06 | wvmarle             | Pull #20  - Numerous changes and enhancements
-* 1.1.0  | 2018-07-05 | wvmarle             | Pull #14  - bug fixes to alarm state and cleaned up comments
-* 1.0.8  | 2018-07-02 | SV-Zanshin          | Added guard code against multiple I2C constant definitions
-* 1.0.8  | 2018-06-30 | SV-Zanshin          | Enh #15   - Added I2C Speed selection
-* 1.0.7  | 2018-06-21 | SV-Zanshin          | Issue #13 - DateTime.dayOfTheWeek() is 0-6 instead of 1-7
-* 1.0.6  | 2018-04-29 | SV-Zanshin          | Issue  #7 - Moved setting of param defaults to prototypes
-* 1.0.6  | 2018-04-29 | SV-Zanshin          | Issue #10 - incorrect setting of alarm with WKDAY to future date
-* 1.0.5b | 2017-12-18 | SV-Zanshin          | Issue  #8 - incorrect setting to 24-Hour clock
-* 1.0.5a | 2017-10-31 | SV-Zanshin          | Issue  #6 - to remove classification on 2 template functions
-* 1.0.4c | 2017-08-13 | SV-Zanshin          | Enhancement #5 to remove checks after Wire.requestFrom()
-* 1.0.4b | 2017-08-08 | SV-Zanshin          | Replaced readRAM and writeRAM with template functions
-* 1.0.4a | 2017-08-06 | SV-Zanshin          | Removed unnecessary MCP7940_I2C_Delay and all references
-* 1.0.3  | 2017-08-05 | SV-Zanshin          | Added calls for MCP7940N. getPowerFail(), clearPowerFail(), setBattery(). Added I2C_READ_ATTEMPTS to prevent I2C hang, added getPowerUp/Down()
-* 1.0.3a | 2017-07-29 | SV-Zanshin          | Cleaned up comments, no code changes
-* 1.0.3  | 2017-07-29 | SV-Zanshin          | Added getSQWSpeed(),setSQWSpeed(),setSQWState() & getSQWState()
-* 1.0.2  | 2017-07-29 | SV-Zanshin          | Added getAlarm(),setAlarmState(),getAlarmState() functions and added the optional setting to setAlarm(). Added isAlarm(). Fixed errors with alarm 1 indexing.
-* 1.0.1  | 2017-07-25 | SV-Zanshin          | Added overloaded Calibrate() to manually set the trim factor
-* 1.0.0  | 2017-07-23 | SV-Zanshin          | Cleaned up code, initial github upload
-* 1.0.2b | 2017-07-20 | SV-Zanshin          | Added alarm handling
-* 1.0.1b | 2017-07-19 | SV-Zanshin          | Added methods
-* 1.0.0b | 2017-07-17 | SV-Zanshin          | Initial coding
-*******************************************************************************************************************/
+/*! @file MCP7940.h
 
+ @mainpage Arduino Library Header for the MCP7940M and MCP7940N Real-Time Clock devices
+
+ @section MCP7940_intro_section Description
+
+Class definition header for the MCP7940 from Microchip. Both the MCP7940N (with battery backup pin= and the
+MCP7940M are supported with this library and they both use the same I2C address. This chip is a Real-Time-Clock
+with an I2C interface. The data sheet located at http://ww1.microchip.com/downloads/en/DeviceDoc/20002292B.pdf
+describes the functionality used in this library.\n
+Use is made of portions of Adafruit's RTClib Version 1.2.0 at https://github.com/adafruit/RTClib which is a
+a fork of the original RTClib from Jeelabs. The re-used code encompasses only the classes for time and date.\n
+
+@section license GNU General Public License v3.0
+This program is free software: you can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+option) any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details. You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+@section author Author
+
+Written by Arnd\@SV-Zanshin
+
+@section versions Changelog
+
+Version| Date       | Developer           | Comments
+------ | ---------- | ------------------- | --------
+1.1.6  | 2019-01-27 | davidlehrian        | Issue #36 - Reopened, changed assignment statements to avoid warning
+1.1.5  | 2019-01-19 | SV-Zanshin          | Issue #40 - Change commenting structure and layout to use doxygen
+1.1.5  | 2019-01-19 | INemesisI           | Issue #37 - Corrected AlarmPolarity bit clearing on setAlarm()
+1.1.5  | 2019-01-19 | SV-Zanshin          | Issue #39 - Small changes to remove compiler warnings for Travis-CI
+1.1.5  | 2019-01-18 | INemesisI           | Issue #38 - Overflow on setting new TRIM value
+1.1.4  | 2018-12-15 | hexeguitar          | Issue #36 - Overflow on I2C_MODES datatype corrected
+1.1.4  | 2018-12-15 | huynh213            | Issue #35 - MCP7940.adjust() function resets the PWRFAIL and VBATEN
+1.1.3  | 2018-08-08 | amgrays             | Issue #32 - invalid return on SetMFP corrected
+1.1.3  | 2018-08-05 | HannesJo0139        | Issue #31 - incorrect calibration trim on negative numbers
+1.1.2  | 2018-08-04 | SV-Zanshin          | Issue #28 - added new calibrate() overload for frequency calibration
+1.1.2  | 2018-07-08 | logicaprogrammabile | Issue #26 - regarding hour bitmasks
+1.1.1  | 2018-07-07 | SV-Zanshin          | Fixed bugs introduced by 14, 20, and 21
+1.1.1  | 2018-07-07 | wvmarle             | Pull #21  - Additional changes
+1.1.1  | 2018-07-06 | wvmarle             | Pull #20  - Numerous changes and enhancements
+1.1.0  | 2018-07-05 | wvmarle             | Pull #14  - bug fixes to alarm state and cleaned up comments
+1.0.8  | 2018-07-02 | SV-Zanshin          | Added guard code against multiple I2C constant definitions
+1.0.8  | 2018-06-30 | SV-Zanshin          | Enh #15   - Added I2C Speed selection
+1.0.7  | 2018-06-21 | SV-Zanshin          | Issue #13 - DateTime.dayOfTheWeek() is 0-6 instead of 1-7
+1.0.6  | 2018-04-29 | SV-Zanshin          | Issue  #7 - Moved setting of param defaults to prototypes
+1.0.6  | 2018-04-29 | SV-Zanshin          | Issue #10 - incorrect setting of alarm with WKDAY to future date
+1.0.5b | 2017-12-18 | SV-Zanshin          | Issue  #8 - incorrect setting to 24-Hour clock
+1.0.5a | 2017-10-31 | SV-Zanshin          | Issue  #6 - to remove classification on 2 template functions
+1.0.4c | 2017-08-13 | SV-Zanshin          | Enhancement #5 to remove checks after Wire.requestFrom()
+1.0.4b | 2017-08-08 | SV-Zanshin          | Replaced readRAM and writeRAM with template functions
+1.0.4a | 2017-08-06 | SV-Zanshin          | Removed unnecessary MCP7940_I2C_Delay and all references
+1.0.3  | 2017-08-05 | SV-Zanshin          | Added calls for MCP7940N. getPowerFail(), clearPowerFail(), setBattery(). Added I2C_READ_ATTEMPTS to prevent I2C hang, added getPowerUp/Down()
+1.0.3a | 2017-07-29 | SV-Zanshin          | Cleaned up comments, no code changes
+1.0.3  | 2017-07-29 | SV-Zanshin          | Added getSQWSpeed(),setSQWSpeed(),setSQWState() & getSQWState()
+1.0.2  | 2017-07-29 | SV-Zanshin          | Added getAlarm(),setAlarmState(),getAlarmState() functions and added the optional setting to setAlarm(). Added isAlarm(). Fixed errors with alarm 1 indexing.
+1.0.1  | 2017-07-25 | SV-Zanshin          | Added overloaded Calibrate() to manually set the trim factor
+1.0.0  | 2017-07-23 | SV-Zanshin          | Cleaned up code, initial github upload
+1.0.2b | 2017-07-20 | SV-Zanshin          | Added alarm handling
+1.0.1b | 2017-07-19 | SV-Zanshin          | Added methods
+1.0.0b | 2017-07-17 | SV-Zanshin          | Initial coding
+
+*/
 #include "Arduino.h"  // Arduino data type definitions
 #include <Wire.h>     // Standard I2C "Wire" library
 #ifndef MCP7940_h     // Guard code definition
@@ -140,12 +137,11 @@
   const uint8_t  MCP7940_ALM1IF            =         3; ///< ALM1WKDAY register
   const uint32_t SECONDS_PER_DAY           =     86400; ///< 60 secs * 60 mins * 24 hours
   const uint32_t SECONDS_FROM_1970_TO_2000 = 946684800; ///< Seconds between year 1970 and 2000
-  /*************************************************************************************************************//*!
-  * @class   DateTime
-  * @brief   Simple general-purpose date/time class
-  * @details Copied from RTClib. For further information on this implementation see 
-  *          https://github.com/SV-Zanshin/MCP7940/wiki/DateTimeClass
-  *****************************************************************************************************************/
+  /*!
+  * @class DateTime
+  * @brief Simple general-purpose date/time class
+  * @details Copied from RTClib. For further information on this implementation see https://github.com/SV-Zanshin/MCP7940/wiki/DateTimeClass
+  */
   class DateTime 
   {
     public:
@@ -186,12 +182,11 @@
       uint8_t   mm; ///< Internal minute value
       uint8_t   ss; ///< Internal seconds
   }; // of class DateTime definition
-  /*************************************************************************************************************//*!
-  * @class   TimeSpan
-  * @brief   Timespan class which can represent changes in time with seconds accuracy
-  * @details Copied from RTClib. For further information see
-  *          https://github.com/SV-Zanshin/MCP7940/wiki/TimeSpanClass for additional details
-  *****************************************************************************************************************/
+  /*!
+  * @class TimeSpan
+  * @brief Timespan class which can represent changes in time with seconds accuracy
+  * @details Copied from RTClib. For further information see https://github.com/SV-Zanshin/MCP7940/wiki/TimeSpanClass
+  */
   class TimeSpan 
   {
     public:
@@ -209,10 +204,10 @@
       int32_t _seconds;                                                      ///< Internal value for total seconds
   }; // of class TimeSpan definition
 
-  /*************************************************************************************************************//*!
-  * @class MCP7940_Class
-  * @brief Main class definition with forward declarations
-  *****************************************************************************************************************/
+/**
+* @class MCP7940_Class
+* @brief Main class definition
+*/
   class MCP7940_Class 
   {
     public:
@@ -251,7 +246,11 @@
       bool     clearPowerFail();
       DateTime getPowerDown();
       DateTime getPowerUp();
-      void   calibrateOrAdjust(const DateTime& dt);
+	  int8_t   calibrateOrAdjust(const DateTime& dt);
+	  int32_t  getPPMDeviation(const DateTime& dt);
+	  void     setSetUnixTime(uint32_t aTime);
+	  uint32_t getSetUnixTime();
+	  
 /*******************************************************************************************************************
 ** Declare the readRAM() and writeRAM() methods as template functions to use for all I2C device I/O. The code has **
 ** to be in the main library definition rather than the actual MCP7940.cpp library file.The template functions    **
@@ -263,14 +262,13 @@
 ** The data is stored in a block of 64 bytes, reading beyond the end of the block causes the address pointer to   **
 ** roll over to the start of the block.                                                                           **
 *******************************************************************************************************************/
-
-/***************************************************************************************************************//*!
-* @brief     Template for readRAM()
-* @details   As a template it can support compile-time data type definitions
-* @param[in] addr Memory address
-* @param[in] value    Data Type "T" to read
-* @return    Pointer to return data structure
-*******************************************************************************************************************/
+/*!
+    @brief     Template for readRAM()
+    @details   As a template it can support compile-time data type definitions
+    @param[in] addr Memory address
+    @param[in] value    Data Type "T" to read
+    @return    Pointer to return data structure
+*/
       template< typename T >
       uint8_t&  readRAM(const uint8_t addr, T &value) 
       {
@@ -290,13 +288,13 @@
         } // of for-next each byte to be read
         return (i);
       } // of method readRAM()
-/***************************************************************************************************************//*!
-* @brief     Template for writeRAM()
-* @details   As a template it can support compile-time data type definitions
-* @param[in] addr Memory address
-* @param[in] value Data Type "T" to write
-* @return    True if successful, otherwise false
-*******************************************************************************************************************/
+/*!
+    @brief     Template for writeRAM()
+    @details   As a template it can support compile-time data type definitions
+    @param[in] addr Memory address
+    @param[in] value Data Type "T" to write
+    @return    True if successful, otherwise false
+*/
       template<typename T>
       bool writeRAM(const uint8_t addr, const T &value) 
       {
@@ -310,26 +308,21 @@
         _TransmissionStatus = Wire.endTransmission();    // Close transmission
         return (!_TransmissionStatus);                   // return error status
       } // of method writeRAM()
-    private:
-      uint8_t  readByte(const uint8_t addr);                         // Read 1 byte from address on I2C
-      void     writeByte(const uint8_t addr, const uint8_t data);    // Write 1 byte at address to I2C
-      uint8_t  bcd2int(const uint8_t bcd);                           // convert BCD digits to integer
-      uint8_t  int2bcd(const uint8_t dec);                           // convert integer to BCD
-      uint8_t  _TransmissionStatus = 0;                              ///< Status of I2C transmission
-      bool     _CrystalStatus     = false;                           ///< True if RTC is turned on
-      bool     _OscillatorStatus  = false;                           ///< True if Oscillator on and working
-      uint32_t _SetUnixTime       = 0;                               ///< UNIX time when clock last set
-      uint8_t  _ss,                                                  ///< Time component Seconds
-               _mm,                                                  ///< Time component Minutes
-               _hh,                                                  ///< Time component Hours
-               _d,                                                   ///< Time component Days
-               _m;                                                   ///< Time component Months
-      uint16_t _y;                                                   ///< Time component Years
-      void     clearRegisterBit(const uint8_t reg, const uint8_t b); // Clear a bit, values 0-7
-      void     setRegisterBit  (const uint8_t reg, const uint8_t b); // Set   a bit, values 0-7
-      void     writeRegisterBit(const uint8_t reg, const uint8_t b,  // Clear a bit, values 0-7
-                                bool bitvalue);                      //                                  //
-      uint8_t  readRegisterBit (const uint8_t reg, const uint8_t b); // Read  a bit, values 0-7
-      int32_t  getPPMDeviation(const DateTime& dt);
-  }; // of MCP7940 class definition
-#endif
+    private:                                                                  // Private methods                  //
+      uint8_t  readByte(const uint8_t addr);                                  // Read 1 byte from address on I2C  //
+      void     writeByte(const uint8_t addr, const uint8_t data);             // Write 1 byte at address to I2C   //
+      uint8_t  bcd2int(const uint8_t bcd);                                    // convert BCD digits to integer    //
+      uint8_t  int2bcd(const uint8_t dec);                                    // convert integer to BCD           //
+      uint8_t  _TransmissionStatus = 0;                                       // Status of I2C transmission       //
+      bool     _CrystalStatus     = false;                                    // True if RTC is turned on         //
+      bool     _OscillatorStatus  = false;                                    // True if Oscillator on and working//
+      uint32_t _SetUnixTime       = 0;                                        // UNIX time when clock last set    //
+      uint8_t  _ss,_mm,_hh,_d,_m;                                             // Define date components           //
+      uint16_t _y;                                                            // Define date components           //
+      void     clearRegisterBit(const uint8_t reg, const uint8_t b);          // Clear a bit, values 0-7          //
+      void     setRegisterBit  (const uint8_t reg, const uint8_t b);          // Set   a bit, values 0-7          //
+      void     writeRegisterBit(const uint8_t reg, const uint8_t b,           // Clear a bit, values 0-7          //
+                                bool bitvalue);                               //                                  //
+      uint8_t  readRegisterBit (const uint8_t reg, const uint8_t b);          // Read  a bit, values 0-7          //
+  }; // of MCP7940 class definition                                           //                                  //
+#endif                                                                        //----------------------------------//

--- a/src/MCP7940.h
+++ b/src/MCP7940.h
@@ -1,68 +1,71 @@
-/*! @file MCP7940.h
+/***************************************************************************************************************//*!
+* @file MCP7940.h
+*
+*  @mainpage Arduino Library Header for the MCP7940M and MCP7940N Real-Time Clock devices
+*
+*  @section MCP7940_intro_section Description
+*
+* Class definition header for the MCP7940 from Microchip. Both the MCP7940N (with battery backup pin= and the
+* MCP7940M are supported with this library and they both use the same I2C address. This chip is a Real-Time-Clock
+* with an I2C interface. The data sheet located at http://ww1.microchip.com/downloads/en/DeviceDoc/20002292B.pdf
+* describes the functionality used in this library.\n
+* Use is made of portions of Adafruit's RTClib Version 1.2.0 at https://github.com/adafruit/RTClib which is a
+* a fork of the original RTClib from Jeelabs. The re-used code encompasses only the classes for time and date.\n
+*
+* @section license GNU General Public License v3.0
+* This program is free software: you can redistribute it and/or modify it under the terms of the GNU General
+* Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+* option) any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details. You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*
+* @section author Author
+*
+* Written by Arnd\@SV-Zanshin
+*
+* @section versions Changelog
+* 
+* Version| Date       | Developer           | Comments
+* ------ | ---------- | ------------------- | --------
+* 1.1.7  | 2019-02-07 | davidlehrian        | Issue #43 - Calibration might cause overflow of "trim" variable
+* 1.1.7  | 2019-02-07 | davidlehrian        | Issue #42 - calibrate(DateTime) should correct the current date/time
+* 1.1.6  | 2019-01-27 | davidlehrian        | Issue #36 - Reopened, changed assignment statements to avoid warning
+* 1.1.5  | 2019-01-19 | SV-Zanshin          | Issue #40 - Change commenting structure and layout to use doxygen
+* 1.1.5  | 2019-01-19 | INemesisI           | Issue #37 - Corrected AlarmPolarity bit clearing on setAlarm()
+* 1.1.5  | 2019-01-19 | SV-Zanshin          | Issue #39 - Small changes to remove compiler warnings for Travis-CI
+* 1.1.5  | 2019-01-18 | INemesisI           | Issue #38 - Overflow on setting new TRIM value
+* 1.1.4  | 2018-12-15 | hexeguitar          | Issue #36 - Overflow on I2C_MODES datatype corrected
+* 1.1.4  | 2018-12-15 | huynh213            | Issue #35 - MCP7940.adjust() function resets the PWRFAIL and VBATEN
+* 1.1.3  | 2018-08-08 | amgrays             | Issue #32 - invalid return on SetMFP corrected
+* 1.1.3  | 2018-08-05 | HannesJo0139        | Issue #31 - incorrect calibration trim on negative numbers
+* 1.1.2  | 2018-08-04 | SV-Zanshin          | Issue #28 - added new calibrate() overload for frequency calibration
+* 1.1.2  | 2018-07-08 | logicaprogrammabile | Issue #26 - regarding hour bitmasks
+* 1.1.1  | 2018-07-07 | SV-Zanshin          | Fixed bugs introduced by 14, 20, and 21
+* 1.1.1  | 2018-07-07 | wvmarle             | Pull #21  - Additional changes
+* 1.1.1  | 2018-07-06 | wvmarle             | Pull #20  - Numerous changes and enhancements
+* 1.1.0  | 2018-07-05 | wvmarle             | Pull #14  - bug fixes to alarm state and cleaned up comments
+* 1.0.8  | 2018-07-02 | SV-Zanshin          | Added guard code against multiple I2C constant definitions
+* 1.0.8  | 2018-06-30 | SV-Zanshin          | Enh #15   - Added I2C Speed selection
+* 1.0.7  | 2018-06-21 | SV-Zanshin          | Issue #13 - DateTime.dayOfTheWeek() is 0-6 instead of 1-7
+* 1.0.6  | 2018-04-29 | SV-Zanshin          | Issue  #7 - Moved setting of param defaults to prototypes
+* 1.0.6  | 2018-04-29 | SV-Zanshin          | Issue #10 - incorrect setting of alarm with WKDAY to future date
+* 1.0.5b | 2017-12-18 | SV-Zanshin          | Issue  #8 - incorrect setting to 24-Hour clock
+* 1.0.5a | 2017-10-31 | SV-Zanshin          | Issue  #6 - to remove classification on 2 template functions
+* 1.0.4c | 2017-08-13 | SV-Zanshin          | Enhancement #5 to remove checks after Wire.requestFrom()
+* 1.0.4b | 2017-08-08 | SV-Zanshin          | Replaced readRAM and writeRAM with template functions
+* 1.0.4a | 2017-08-06 | SV-Zanshin          | Removed unnecessary MCP7940_I2C_Delay and all references
+* 1.0.3  | 2017-08-05 | SV-Zanshin          | Added calls for MCP7940N. getPowerFail(), clearPowerFail(), setBattery(). Added I2C_READ_ATTEMPTS to prevent I2C hang, added getPowerUp/Down()
+* 1.0.3a | 2017-07-29 | SV-Zanshin          | Cleaned up comments, no code changes
+* 1.0.3  | 2017-07-29 | SV-Zanshin          | Added getSQWSpeed(),setSQWSpeed(),setSQWState() & getSQWState()
+* 1.0.2  | 2017-07-29 | SV-Zanshin          | Added getAlarm(),setAlarmState(),getAlarmState() functions and added the optional setting to setAlarm(). Added isAlarm(). Fixed errors with alarm 1 indexing.
+* 1.0.1  | 2017-07-25 | SV-Zanshin          | Added overloaded Calibrate() to manually set the trim factor
+* 1.0.0  | 2017-07-23 | SV-Zanshin          | Cleaned up code, initial github upload
+* 1.0.2b | 2017-07-20 | SV-Zanshin          | Added alarm handling
+* 1.0.1b | 2017-07-19 | SV-Zanshin          | Added methods
+* 1.0.0b | 2017-07-17 | SV-Zanshin          | Initial coding
+*******************************************************************************************************************/
 
- @mainpage Arduino Library Header for the MCP7940M and MCP7940N Real-Time Clock devices
-
- @section MCP7940_intro_section Description
-
-Class definition header for the MCP7940 from Microchip. Both the MCP7940N (with battery backup pin= and the
-MCP7940M are supported with this library and they both use the same I2C address. This chip is a Real-Time-Clock
-with an I2C interface. The data sheet located at http://ww1.microchip.com/downloads/en/DeviceDoc/20002292B.pdf
-describes the functionality used in this library.\n
-Use is made of portions of Adafruit's RTClib Version 1.2.0 at https://github.com/adafruit/RTClib which is a
-a fork of the original RTClib from Jeelabs. The re-used code encompasses only the classes for time and date.\n
-
-@section license GNU General Public License v3.0
-This program is free software: you can redistribute it and/or modify it under the terms of the GNU General
-Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
-option) any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY
-WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details. You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-@section author Author
-
-Written by Arnd\@SV-Zanshin
-
-@section versions Changelog
-
-Version| Date       | Developer           | Comments
------- | ---------- | ------------------- | --------
-1.1.6  | 2019-01-27 | davidlehrian        | Issue #36 - Reopened, changed assignment statements to avoid warning
-1.1.5  | 2019-01-19 | SV-Zanshin          | Issue #40 - Change commenting structure and layout to use doxygen
-1.1.5  | 2019-01-19 | INemesisI           | Issue #37 - Corrected AlarmPolarity bit clearing on setAlarm()
-1.1.5  | 2019-01-19 | SV-Zanshin          | Issue #39 - Small changes to remove compiler warnings for Travis-CI
-1.1.5  | 2019-01-18 | INemesisI           | Issue #38 - Overflow on setting new TRIM value
-1.1.4  | 2018-12-15 | hexeguitar          | Issue #36 - Overflow on I2C_MODES datatype corrected
-1.1.4  | 2018-12-15 | huynh213            | Issue #35 - MCP7940.adjust() function resets the PWRFAIL and VBATEN
-1.1.3  | 2018-08-08 | amgrays             | Issue #32 - invalid return on SetMFP corrected
-1.1.3  | 2018-08-05 | HannesJo0139        | Issue #31 - incorrect calibration trim on negative numbers
-1.1.2  | 2018-08-04 | SV-Zanshin          | Issue #28 - added new calibrate() overload for frequency calibration
-1.1.2  | 2018-07-08 | logicaprogrammabile | Issue #26 - regarding hour bitmasks
-1.1.1  | 2018-07-07 | SV-Zanshin          | Fixed bugs introduced by 14, 20, and 21
-1.1.1  | 2018-07-07 | wvmarle             | Pull #21  - Additional changes
-1.1.1  | 2018-07-06 | wvmarle             | Pull #20  - Numerous changes and enhancements
-1.1.0  | 2018-07-05 | wvmarle             | Pull #14  - bug fixes to alarm state and cleaned up comments
-1.0.8  | 2018-07-02 | SV-Zanshin          | Added guard code against multiple I2C constant definitions
-1.0.8  | 2018-06-30 | SV-Zanshin          | Enh #15   - Added I2C Speed selection
-1.0.7  | 2018-06-21 | SV-Zanshin          | Issue #13 - DateTime.dayOfTheWeek() is 0-6 instead of 1-7
-1.0.6  | 2018-04-29 | SV-Zanshin          | Issue  #7 - Moved setting of param defaults to prototypes
-1.0.6  | 2018-04-29 | SV-Zanshin          | Issue #10 - incorrect setting of alarm with WKDAY to future date
-1.0.5b | 2017-12-18 | SV-Zanshin          | Issue  #8 - incorrect setting to 24-Hour clock
-1.0.5a | 2017-10-31 | SV-Zanshin          | Issue  #6 - to remove classification on 2 template functions
-1.0.4c | 2017-08-13 | SV-Zanshin          | Enhancement #5 to remove checks after Wire.requestFrom()
-1.0.4b | 2017-08-08 | SV-Zanshin          | Replaced readRAM and writeRAM with template functions
-1.0.4a | 2017-08-06 | SV-Zanshin          | Removed unnecessary MCP7940_I2C_Delay and all references
-1.0.3  | 2017-08-05 | SV-Zanshin          | Added calls for MCP7940N. getPowerFail(), clearPowerFail(), setBattery(). Added I2C_READ_ATTEMPTS to prevent I2C hang, added getPowerUp/Down()
-1.0.3a | 2017-07-29 | SV-Zanshin          | Cleaned up comments, no code changes
-1.0.3  | 2017-07-29 | SV-Zanshin          | Added getSQWSpeed(),setSQWSpeed(),setSQWState() & getSQWState()
-1.0.2  | 2017-07-29 | SV-Zanshin          | Added getAlarm(),setAlarmState(),getAlarmState() functions and added the optional setting to setAlarm(). Added isAlarm(). Fixed errors with alarm 1 indexing.
-1.0.1  | 2017-07-25 | SV-Zanshin          | Added overloaded Calibrate() to manually set the trim factor
-1.0.0  | 2017-07-23 | SV-Zanshin          | Cleaned up code, initial github upload
-1.0.2b | 2017-07-20 | SV-Zanshin          | Added alarm handling
-1.0.1b | 2017-07-19 | SV-Zanshin          | Added methods
-1.0.0b | 2017-07-17 | SV-Zanshin          | Initial coding
-
-*/
 #include "Arduino.h"  // Arduino data type definitions
 #include <Wire.h>     // Standard I2C "Wire" library
 #ifndef MCP7940_h     // Guard code definition
@@ -137,11 +140,12 @@ Version| Date       | Developer           | Comments
   const uint8_t  MCP7940_ALM1IF            =         3; ///< ALM1WKDAY register
   const uint32_t SECONDS_PER_DAY           =     86400; ///< 60 secs * 60 mins * 24 hours
   const uint32_t SECONDS_FROM_1970_TO_2000 = 946684800; ///< Seconds between year 1970 and 2000
-  /*!
-  * @class DateTime
-  * @brief Simple general-purpose date/time class
-  * @details Copied from RTClib. For further information on this implementation see https://github.com/SV-Zanshin/MCP7940/wiki/DateTimeClass
-  */
+  /*************************************************************************************************************//*!
+  * @class   DateTime
+  * @brief   Simple general-purpose date/time class
+  * @details Copied from RTClib. For further information on this implementation see 
+  *          https://github.com/SV-Zanshin/MCP7940/wiki/DateTimeClass
+  *****************************************************************************************************************/
   class DateTime 
   {
     public:
@@ -182,11 +186,12 @@ Version| Date       | Developer           | Comments
       uint8_t   mm; ///< Internal minute value
       uint8_t   ss; ///< Internal seconds
   }; // of class DateTime definition
-  /*!
-  * @class TimeSpan
-  * @brief Timespan class which can represent changes in time with seconds accuracy
-  * @details Copied from RTClib. For further information see https://github.com/SV-Zanshin/MCP7940/wiki/TimeSpanClass
-  */
+  /*************************************************************************************************************//*!
+  * @class   TimeSpan
+  * @brief   Timespan class which can represent changes in time with seconds accuracy
+  * @details Copied from RTClib. For further information see
+  *          https://github.com/SV-Zanshin/MCP7940/wiki/TimeSpanClass for additional details
+  *****************************************************************************************************************/
   class TimeSpan 
   {
     public:
@@ -204,10 +209,10 @@ Version| Date       | Developer           | Comments
       int32_t _seconds;                                                      ///< Internal value for total seconds
   }; // of class TimeSpan definition
 
-/**
-* @class MCP7940_Class
-* @brief Main class definition
-*/
+  /*************************************************************************************************************//*!
+  * @class MCP7940_Class
+  * @brief Main class definition with forward declarations
+  *****************************************************************************************************************/
   class MCP7940_Class 
   {
     public:
@@ -250,7 +255,6 @@ Version| Date       | Developer           | Comments
 	  int32_t  getPPMDeviation(const DateTime& dt);
 	  void     setSetUnixTime(uint32_t aTime);
 	  uint32_t getSetUnixTime();
-	  
 /*******************************************************************************************************************
 ** Declare the readRAM() and writeRAM() methods as template functions to use for all I2C device I/O. The code has **
 ** to be in the main library definition rather than the actual MCP7940.cpp library file.The template functions    **
@@ -262,13 +266,14 @@ Version| Date       | Developer           | Comments
 ** The data is stored in a block of 64 bytes, reading beyond the end of the block causes the address pointer to   **
 ** roll over to the start of the block.                                                                           **
 *******************************************************************************************************************/
-/*!
-    @brief     Template for readRAM()
-    @details   As a template it can support compile-time data type definitions
-    @param[in] addr Memory address
-    @param[in] value    Data Type "T" to read
-    @return    Pointer to return data structure
-*/
+
+/***************************************************************************************************************//*!
+* @brief     Template for readRAM()
+* @details   As a template it can support compile-time data type definitions
+* @param[in] addr Memory address
+* @param[in] value    Data Type "T" to read
+* @return    Pointer to return data structure
+*******************************************************************************************************************/
       template< typename T >
       uint8_t&  readRAM(const uint8_t addr, T &value) 
       {
@@ -288,13 +293,13 @@ Version| Date       | Developer           | Comments
         } // of for-next each byte to be read
         return (i);
       } // of method readRAM()
-/*!
-    @brief     Template for writeRAM()
-    @details   As a template it can support compile-time data type definitions
-    @param[in] addr Memory address
-    @param[in] value Data Type "T" to write
-    @return    True if successful, otherwise false
-*/
+/***************************************************************************************************************//*!
+* @brief     Template for writeRAM()
+* @details   As a template it can support compile-time data type definitions
+* @param[in] addr Memory address
+* @param[in] value Data Type "T" to write
+* @return    True if successful, otherwise false
+*******************************************************************************************************************/
       template<typename T>
       bool writeRAM(const uint8_t addr, const T &value) 
       {
@@ -308,21 +313,25 @@ Version| Date       | Developer           | Comments
         _TransmissionStatus = Wire.endTransmission();    // Close transmission
         return (!_TransmissionStatus);                   // return error status
       } // of method writeRAM()
-    private:                                                                  // Private methods                  //
-      uint8_t  readByte(const uint8_t addr);                                  // Read 1 byte from address on I2C  //
-      void     writeByte(const uint8_t addr, const uint8_t data);             // Write 1 byte at address to I2C   //
-      uint8_t  bcd2int(const uint8_t bcd);                                    // convert BCD digits to integer    //
-      uint8_t  int2bcd(const uint8_t dec);                                    // convert integer to BCD           //
-      uint8_t  _TransmissionStatus = 0;                                       // Status of I2C transmission       //
-      bool     _CrystalStatus     = false;                                    // True if RTC is turned on         //
-      bool     _OscillatorStatus  = false;                                    // True if Oscillator on and working//
-      uint32_t _SetUnixTime       = 0;                                        // UNIX time when clock last set    //
-      uint8_t  _ss,_mm,_hh,_d,_m;                                             // Define date components           //
-      uint16_t _y;                                                            // Define date components           //
-      void     clearRegisterBit(const uint8_t reg, const uint8_t b);          // Clear a bit, values 0-7          //
-      void     setRegisterBit  (const uint8_t reg, const uint8_t b);          // Set   a bit, values 0-7          //
-      void     writeRegisterBit(const uint8_t reg, const uint8_t b,           // Clear a bit, values 0-7          //
-                                bool bitvalue);                               //                                  //
-      uint8_t  readRegisterBit (const uint8_t reg, const uint8_t b);          // Read  a bit, values 0-7          //
-  }; // of MCP7940 class definition                                           //                                  //
-#endif                                                                        //----------------------------------//
+    private:
+      uint8_t  readByte(const uint8_t addr);                         // Read 1 byte from address on I2C
+      void     writeByte(const uint8_t addr, const uint8_t data);    // Write 1 byte at address to I2C
+      uint8_t  bcd2int(const uint8_t bcd);                           // convert BCD digits to integer
+      uint8_t  int2bcd(const uint8_t dec);                           // convert integer to BCD
+      uint8_t  _TransmissionStatus = 0;                              ///< Status of I2C transmission
+      bool     _CrystalStatus     = false;                           ///< True if RTC is turned on
+      bool     _OscillatorStatus  = false;                           ///< True if Oscillator on and working
+      uint32_t _SetUnixTime       = 0;                               ///< UNIX time when clock last set
+      uint8_t  _ss,                                                  ///< Time component Seconds
+               _mm,                                                  ///< Time component Minutes
+               _hh,                                                  ///< Time component Hours
+               _d,                                                   ///< Time component Days
+               _m;                                                   ///< Time component Months
+      uint16_t _y;                                                   ///< Time component Years
+      void     clearRegisterBit(const uint8_t reg, const uint8_t b); // Clear a bit, values 0-7
+      void     setRegisterBit  (const uint8_t reg, const uint8_t b); // Set   a bit, values 0-7
+      void     writeRegisterBit(const uint8_t reg, const uint8_t b,  // Clear a bit, values 0-7
+                                bool bitvalue);                      //                                  //
+      uint8_t  readRegisterBit (const uint8_t reg, const uint8_t b); // Read  a bit, values 0-7
+  }; // of MCP7940 class definition
+#endif

--- a/src/MCP7940.h
+++ b/src/MCP7940.h
@@ -251,6 +251,7 @@
       bool     clearPowerFail();
       DateTime getPowerDown();
       DateTime getPowerUp();
+      void   calibrateOrAdjust(const DateTime& dt);
 /*******************************************************************************************************************
 ** Declare the readRAM() and writeRAM() methods as template functions to use for all I2C device I/O. The code has **
 ** to be in the main library definition rather than the actual MCP7940.cpp library file.The template functions    **
@@ -329,5 +330,6 @@
       void     writeRegisterBit(const uint8_t reg, const uint8_t b,  // Clear a bit, values 0-7
                                 bool bitvalue);                      //                                  //
       uint8_t  readRegisterBit (const uint8_t reg, const uint8_t b); // Read  a bit, values 0-7
+      int32_t  getPPMDeviation(const DateTime& dt);
   }; // of MCP7940 class definition
 #endif


### PR DESCRIPTION
Added new method  int8_t calibrateOrAdjust(const DateTime& dt).

# Description
Added a public method int8_t calibrateOrAdjust(const DateTime& dt); which will calibrate and adjust the the clock if the PPM error is in the range of -130 to 130.  Otherwise it will only adjust the clock and the trim is left alone.  In both cases it returns the trim value.  

Also fixed a potential overflow error by changing the trim variable data type to int16_t in the calibrate(const DateTime& dt) method.  This variable holds the result of an addition process which may overflow the 8 bit variable.  The value is then clamped to be between -127 and 127 and converted back to int8_t before being set as the trim value.  

Fixes # (43)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Here is a test program that will set the time and then adjust the _SetUnixTime variable (through 2 newly added set/get method) to generate PPM errors of 100 and 131 and it shows how in the case of 100 PPM error the trim value is set and the time is updated and in the case of 131 PPM error the trim value is left alone and the time is updated.  

In order to run this test there were 2 public methods created solely for implementing the test code:
	  void     setSetUnixTime(uint32_t aTime);
	  uint32_t getSetUnixTime();

And one method that could be private but was made public in order to display the PPM error in the test code.  
	  int32_t  getPPMDeviation(const DateTime& dt);

#include <MCP7940.h>
MCP7940_Class mcp7940; 
void setup() {
  // set up serial output
  Serial.begin(115200);
  // wait until the serial stream is open DML 2/7/2019
  while (!Serial) ;
  // start the MCP7940 real time clock  DML 2/7/2019
  mcp7940.begin();
  // set the trim to 0  DML 2/7/2019
  int8_t trim = mcp7940.calibrate();
  // set the time to 2019-02-02 13:15:00, don't need to start the oscillator as it is started
  // when the time is set  DML 2/7/2019
  mcp7940.adjust(DateTime(2019,2,7,13,15,0));
  // print the trim value which should be 0  DML 2/7/2019
  Serial.print("Trim (should be 0): ");
  Serial.println(trim);
  // print the date and time which should be 2019-02-07 13:15:00  DML 2/7/2019
  DateTime now = mcp7940.now();
  Serial.print("Date and Time (should be 2019-02-07 13:15:00): ");  
  char dateBuffer[32];
  sprintf(dateBuffer,"%04d-%02d-%02d %02d:%02d:%02d", now.year(),now.month(), now.day(), now.hour(), now.minute(), now.second());
  Serial.println(dateBuffer);
 
  // now change the time by an amount that will calculate a ppm error > 130  DML 2/7/2019
  // for this test I made the getPPMDeviation method public so I can call it from the test code  DML 2/7/2019
  // as the chip is dealing with seconds when calculating PPM error it is unrealistic to wait for 7,632 seconds 
  // (2 hours 7 minutes) to change the clock by 1 second to create a 131 PPM error to test this code so I 
  // created methods to set and get the _SetUnixTime variable so the 131 PPM error can be created in a 
  // reasonable time frame  DML 2/7/2019
  mcp7940.setSetUnixTime(mcp7940.getSetUnixTime() - 7632);
  // use a DateTime that is one second from the time set on the clock which is a PPM error of 131  DML 2/7/2019
  DateTime dt = DateTime(2019,2,7,13,15,1);
  int32_t ppmDeviation = mcp7940.getPPMDeviation(dt);
  Serial.print("PPM Deviation (should be 131): ");  
  Serial.println(ppmDeviation);  

  // call method we are testing  DML 2/7/2019
  trim = mcp7940.calibrateOrAdjust(dt);
  // print the trim value should still be 0  DML 2/7/2019
  Serial.print("Trim (should be 0): ");
  Serial.println(trim);
  now = mcp7940.now();
  // print the date and time which should be 2019-02-07 13:15:01  DML 2/7/2019
  Serial.print("Date and Time (should be 2019-02-07 13:15:01): ");  
  sprintf(dateBuffer,"%04d-%02d-%02d %02d:%02d:%02d", now.year(),now.month(), now.day(), now.hour(), now.minute(), now.second());
  Serial.println(dateBuffer);

  // as the chip is dealing with seconds when calculating PPM error it is unrealistic to wait for 10,000 seconds 
  // (2 hours 47 minutes) to change the clock by 1 second to create a 100 PPM error to test this code 
  dt = DateTime(2019,2,7,13,15,02);
  // assume the time was set 10,000 seconds ago (actually subtract 9999 as one second has elapsed since
  // the clock was last set) DML 2/7/2019
  mcp7940.setSetUnixTime(mcp7940.getSetUnixTime() - 9999);
  // the dt is 1 sec off the previous time so the PPM deviation should be 100  DML 2/7/2019
  ppmDeviation = mcp7940.getPPMDeviation(dt);
  Serial.print("PPM Deviation (should be 100): ");  
  Serial.println(ppmDeviation);  

  // call method we are testing  DML 2/7/2019
  trim = mcp7940.calibrateOrAdjust(dt);
  // print the trim value which should be 100 * 32768 * 60 / 2000000 = 98;  DML 2/7/2019
  Serial.print("Trim (should be 98): ");
  Serial.println(trim);
  now = mcp7940.now();
  // print the date and time which should be 2019-02-07 13:15:02  DML 2/7/2019
  Serial.print("Date and Time (should be 2019-02-07 13:15:02): ");  
  sprintf(dateBuffer,"%04d-%02d-%02d %02d:%02d:%02d", now.year(),now.month(), now.day(), now.hour(), now.minute(), now.second());
  Serial.println(dateBuffer);
}

void loop() {
  // put your main code here, to run repeatedly:

}

**Test Configuration**:
* Arduino Hardware: Arduino Nano (ATMega328P)
* SDK: Arduino IDE 1.8.8

# Checklist:

- [x] The changes made link back to an existing issue number
- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation / Wiki Page(s)
- [x] My changes generate no new warnings
- [x] I have checked potential areas where regression errors could occur and have found no issues
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

![Zanshin Logo](https://www.sv-zanshin.com/r/images/site/gif/zanshinkanjitiny.gif) <img src="https://www.sv-zanshin.com/r/images/site/gif/zanshintext.gif" width="75"/>
