### PR TITLE
Add new method to obtain the time and date from the RTC without requiring a DateTime object.

### DIFF
--- a/src/MCP7940.cpp
+++ b/src/MCP7940.cpp
@@ -249,7 +249,7 @@ bool MCP7940_Class::begin(const uint8_t sda, const uint8_t scl, const uint32_t i
   */
 #if defined(ESP8266)
   Wire.begin(sda, scl);  // Start I2C as master device using the specified SDA and SCL
-#elif
+#else
   Wire.begin();  // Start I2C as master device
 #endif
   (void)sda;                // force compiler to ignore this potentially unused parameter

--- a/src/MCP7940.cpp
+++ b/src/MCP7940.cpp
@@ -53,6 +53,8 @@ static uint8_t conv2d(const char* p) {
   if ('0' <= *p && *p <= '9') { v = *p - '0'; }  // of if-then character in range
   return 10 * v + *++p - '0';
 }  // of method conv2d
+
+
 DateTime::DateTime(uint32_t t) {
   /*!
    @brief   DateTime constructor (overloaded)
@@ -877,3 +879,20 @@ bool MCP7940_Class::clearPowerFail() const {
   I2C_write(MCP7940_RTCWKDAY, readByte(MCP7940_RTCWKDAY));
   return true;
 }  // of method clearPowerFail()
+bool MCP7940_Class::getTimeDate(DateTime_t &dateTimeStuct) const
+{
+  /*!
+      @brief     Reads the current date/time from the RTC and populates the DateTime_t structure. Avoids creating a DateTime object.
+      @return    True if the RTC was read successfully, otherwise false.
+  */
+  uint8_t readBuffer[7] = {0};
+  uint8_t bytesRead = I2C_read(MCP7940_RTCSEC, readBuffer);
+  dateTimeStuct.year = bcd2int(readBuffer[6]) + 2000;
+  dateTimeStuct.month = bcd2int(readBuffer[5] & 0x1F);
+  dateTimeStuct.day = bcd2int(readBuffer[4] & 0x3F);
+  dateTimeStuct.hour = bcd2int(readBuffer[2] & 0x3F);
+  dateTimeStuct.minute = bcd2int(readBuffer[1] & 0x7F);
+  dateTimeStuct.second = bcd2int(readBuffer[0] & 0x7F);
+  dateTimeStuct.weekday = readBuffer[3] & 0x07;
+  return bytesRead == 7;
+} // of method getTimeDate()

--- a/src/MCP7940.h
+++ b/src/MCP7940.h
@@ -178,7 +178,22 @@ const uint8_t  MCP7940_ALM0IF{3};              ///< ALM0WKDAY register
 const uint8_t  MCP7940_ALM1IF{3};              ///< ALM1WKDAY register
 const uint32_t SECS_1970_TO_2000{946684800};   ///< Seconds between year 1970 and 2000
 
-class DateTime {
+struct DateTime_t
+{
+  /*!
+    @struct DateTime_t
+    @brief  Structure to hold date and time information
+  */
+  uint8_t second;
+  uint8_t minute;
+  uint8_t hour;
+  uint8_t weekday;
+  uint8_t day;
+  uint8_t month;
+  uint16_t year;
+};
+class DateTime
+{
   /*!
     @class   DateTime
     @brief   Simple general-purpose date/time class
@@ -225,7 +240,7 @@ class DateTime {
   uint8_t hh;    ///< Internal hour value
   uint8_t mm;    ///< Internal minute value
   uint8_t ss;    ///< Internal seconds
-};               // of class DateTime definition
+}; // of class DateTime definition
 class TimeSpan {
   /*!
    @class   TimeSpan
@@ -296,6 +311,7 @@ class MCP7940_Class {
   int32_t  getPPMDeviation(const DateTime& dt) const;
   void     setSetUnixTime(uint32_t aTime);
   uint32_t getSetUnixTime() const;
+  bool getTimeDate(DateTime_t& dt) const;
 
   /*************************************************************************************************
   ** Template functions definitions are done in the header file                                   **


### PR DESCRIPTION
# Description
The PR adds a new method to the MCP7940_Class object which populates a DateTime_t struct with the time and date as read from the RTC. The intention is to provide a method to to obtain the time and date without requiring a DateTime object. 

Prototype:
```bool getTimeDate(DateTime_t&);```

Example usage (arduino code shown):

```c++
char dtStr[35];
MCP7940_Class RTC

void setup()
{
  RTC.begin(); // assumes the RTC has already been set
}

void loop()
{
  DateTime_t dt;
  RTC.getTimeDate(dt);
  snprintf(dtStr, sizeof(dtStr) - 1, "Time: %02u:%02u:%02u, Date: %04u/%02u/%02u\n",
           dt.hour, dt.minute, dt.second, dt.year, dt.month, dt.day);
  Serial.print(dtStr);
  delay(1000);
}
```

Fixes # (issue)
N/A

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

Doxtgen update required. I have included comments in the code which are hopefully compatible with Doxygen.

# How Has This Been Tested?

Tested in ESP32 environment on Arduino platform as per the example shown above. Requires minimal testing the the new method does no memory allocation/de-allocation.


# Checklist:

- [ ] The changes made link back to an existing issue number
- [X] I have performed a self-review of my own code
- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] The code adheres to the [Google Style Guide](https://google.github.io/styleguide/cppguide.html)
- [X] The code follows the existing program documentation style using [doxygen](http://www.doxygen.nl/)
- [ ] I have made corresponding changes to the documentation / Wiki Page(s)
- [X] My changes generate no new warnings
- [ ] The automated TRAVIS-CI run has a status of "passed"
- [X] I have checked potential areas where regression errors could occur and have found no issues
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

[![Zanshin Logo](https://zanduino.github.io/Images/zanshinkanjitiny.gif) <img src="https://zanduino.github.io/Images/zanshintext.gif" width="75"/>](https://zanduino.github.io)
